### PR TITLE
Separate current ticket tab

### DIFF
--- a/teller-app/src/hooks/hooks.jsx
+++ b/teller-app/src/hooks/hooks.jsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+/**
+ * A hook for using the native JS interval API. The interval is released after the user component dismounts.
+ * @param callback function to be executed
+ * @param period interval between executions of the callback function. The first execution happens instantly.
+ */
+export function useInterval(callback, period) {
+    useEffect(() => {
+        const interval = setInterval(() => callback(), period)
+        return () => clearInterval(interval);
+    }, [ period ]);
+}

--- a/teller-app/src/pages/CurrentTicketPage/CurrentTicketPage.jsx
+++ b/teller-app/src/pages/CurrentTicketPage/CurrentTicketPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import { useInterval } from '../../hooks/hooks.jsx';
 import { fetchData } from '../../fetching/Fetch.js';
 import { SERVER_URL } from '../../constants.js';
 import '../CurrentTicketPage/CurrentTicketPage.css';
@@ -11,6 +12,8 @@ export default function CurrentTicketPage() {
     useEffect(() => {
         fetchCurrentTicket();
     }, [stationId]);
+
+    useInterval(() => fetchCurrentTicket(), 3000);
 
     const fetchCurrentTicket = async () => {
         try {

--- a/teller-app/src/pages/ShowQueuesForTellerPage/ShowQueuesForTellerPage.jsx
+++ b/teller-app/src/pages/ShowQueuesForTellerPage/ShowQueuesForTellerPage.jsx
@@ -58,7 +58,7 @@ const ShowQueuesForTellerPage = () =>{
             >
                 Advance Queue
             </Button>
-            <Link to={`/display/${tellerStationId}`}>
+            <Link to={`/display/${tellerStationId}`} target="_blank" rel="noopener noreferrer">
                 <Button
                     variant="secondary"
                     style={{ marginLeft: '10px' }}


### PR DESCRIPTION
### Description
It was requested that the tab for the display which shows the current ticket for a teller station opens by default in another tab. In addition to this we also now fetch the data for the current ticket on an interval.